### PR TITLE
DockerイメージビルドのCIの追加とビルドがコケるのを修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,11 @@
+name: build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: docker build -t egison/egison:latest .
+    - run: docker run --rm -i egison/egison:latest -v

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,13 @@
+name: schedule
+
+on:
+  schedule:
+    - cron:  '0 11 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: docker build -t egison/egison:latest .
+    - run: docker run --rm -i egison/egison:latest -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
-FROM phusion/baseimage:latest
+FROM haskell:latest
 MAINTAINER Satoshi Egi
 
-RUN locale-gen en_US.UTF-8  
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8
-
-RUN apt-get update
-RUN apt-get -y install libncurses-dev
-RUN apt-get -y install haskell-platform
 RUN cabal update
-RUN cabal install egison egison-tutorial
-ENV PATH /root/.cabal/bin:$PATH
+RUN cabal install \
+    egison \
+    egison-tutorial
 
 WORKDIR /docker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update
 RUN apt-get -y install libncurses-dev
 RUN apt-get -y install haskell-platform
 RUN cabal update
-RUN cabal install egison
+RUN cabal install egison egison-tutorial
 ENV PATH /root/.cabal/bin:$PATH
 
 WORKDIR /docker

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The Egison Programming Language
 
+![Build Status](https://github.com/egison/docker-egison/workflows/build/badge.svg)
+
 Egison is the **pattern-matching-oriented**, purely functional programming language.
 We can directly represent pattern-matching against lists, multisets, sets, trees, graphs and any kind of data types.
 This is the docker repository of the interpreter of Egison.


### PR DESCRIPTION
* Dockerイメージのビルドが失敗していたので成功するように修正
* いつのまにかイメージのビルドに失敗している、ということを検知できるように日次でイメージをビルドするCIワークフローを追加