### PR TITLE
Add `build-arg` to scheduled testing CI

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -10,5 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: docker build -t egison/egison:latest .
-      - run: docker run --rm -i egison/egison:latest -v
+      - name: Check latest Egison version
+        run: |
+          echo "EGISON_LATEST=$(
+            curl -s https://hackage.haskell.org/package/egison |
+            grep -oE '<strong>[0-9]+\.[0-9]+\.[0-9]+' | sed 's/<strong>//'
+          )" >> "$GITHUB_ENV"
+      - name: Build
+        run: |
+          docker build -t egison/egison:latest . \
+                       --build-arg EGISON_VERSION="$EGISON_LATEST" \
+                       --build-arg HASKELL_VERSION="8" .
+      - name: Run
+        run: docker run --rm -i egison/egison:latest -v


### PR DESCRIPTION
To build correctly, I added two `build-arg` to `docker build` in `schedule.yml`.

Note:

```shellsession
$ echo "EGISON_LATEST=$(
    curl -s https://hackage.haskell.org/package/egison |
    grep -oE '<strong>[0-9]+\.[0-9]+\.[0-9]+' | sed 's/<strong>//'
  )"
EGISON_LATEST=4.1.2
```